### PR TITLE
enhance: rename generated_mac to xen_mac

### DIFF
--- a/xenserver/resource_vif.go
+++ b/xenserver/resource_vif.go
@@ -33,12 +33,12 @@ import (
 )
 
 const (
-	vifSchemaNetworkUUID  = "network_uuid"
-	vifSchemaMac          = "mac"
-	vifSchemaGeneratedMac = "generated_mac"
-	vifSchemaMtu          = "mtu"
-	vifSchemaDevice       = "device"
-	vifSchemaOtherConfig  = "other_config"
+	vifSchemaNetworkUUID = "network_uuid"
+	vifSchemaMac         = "mac"
+	vifSchemaXenMac      = "xen_mac"
+	vifSchemaMtu         = "mtu"
+	vifSchemaDevice      = "device"
+	vifSchemaOtherConfig = "other_config"
 )
 
 func readVIFsFromSchema(c *Connection, s []interface{}) ([]*VIFDescriptor, error) {
@@ -90,12 +90,12 @@ func fillVIFSchema(vif VIFDescriptor) map[string]interface{} {
 		mac = vif.MAC
 	}
 	return map[string]interface{}{
-		vifSchemaNetworkUUID:  vif.Network.UUID,
-		vifSchemaMac:          mac,
-		vifSchemaGeneratedMac: vif.MAC,
-		vifSchemaMtu:          vif.MTU,
-		vifSchemaDevice:       vif.DeviceOrder,
-		vifSchemaOtherConfig:  vif.OtherConfig,
+		vifSchemaNetworkUUID: vif.Network.UUID,
+		vifSchemaMac:         mac,
+		vifSchemaXenMac:      vif.MAC,
+		vifSchemaMtu:         vif.MTU,
+		vifSchemaDevice:      vif.DeviceOrder,
+		vifSchemaOtherConfig: vif.OtherConfig,
 	}
 }
 
@@ -195,7 +195,7 @@ func resourceVIF() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			vifSchemaGeneratedMac: &schema.Schema{
+			vifSchemaXenMac: &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,


### PR DESCRIPTION
rename generated_mac field to xen_mac to signify both specified mac or generated mac in Xen.